### PR TITLE
Fixed issue with trim in QueueTest.java

### DIFF
--- a/pa4/ModelQueueTest.java
+++ b/pa4/ModelQueueTest.java
@@ -83,7 +83,8 @@ class ModelQueueTest {
           A.enqueue(A.peek());
         }
         A.enqueue(B);
-        str += " ";
+        // this line causes an issue because what is being compared is trimmed
+        //str += " ";
         if (!A.toString().trim().equals(str)) return 5;
         A.dequeueAll();
         if (A.length() != B.length()) return 6;


### PR DESCRIPTION
The user's .toString() function is trimmed then compared to a string that has a space appended to the end. This causes an impassable test